### PR TITLE
Link to VPN Download and Loading Animation Changed

### DIFF
--- a/wiki.html
+++ b/wiki.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport">
-    <title>维基词条-郑常龙</title>
+    <title>维基词条(套壳引擎)</title>
     <link rel="stylesheet" href="wiki/wiki.css">
     <script src="https://cdn.bootcss.com/jquery/3.2.1/jquery.min.js"></script>
     <script type="text/javascript" src="wiki/wiki.js"></script>
@@ -12,7 +12,7 @@
 
 <body>
     <div class="main">
-        <a href="https://zh.wikipedia.org/wiki/Wikipedia:%E9%A6%96%E9%A1%B5" target="_blank" class="wikiLogo"><img class="wikiLogo" src="wiki/wikiLogo.png" alt="wiki logo"></a>
+        <a href="https://zh.wikipedia.org/wiki/Wikipedia:%E9%A6%96%E9%A1%B5" target="_blank" class="wikiLogo"><img class="wikiLogo" src="wiki/img/wikiLogo.png" alt="wiki logo"></a>
         <br>
         <input type="text" name="srchIpt" id="srchIpt" class="srchIpt">
         <br>
@@ -23,7 +23,7 @@
         <span class="srcClose">⊕</span>
         </a>
             <br>
-            <a class="srcLink" href="https://www.mike652638.com/download" target="_blank">翻墙工具下载
+            <a class="srcLink" href="http://pan.baidu.com/s/1c28FK9U" target="_blank">翻墙工具下载
         <span class="srcClose">⊕</span>
         </a>
         </div>
@@ -31,7 +31,7 @@
     <div class="resultPage">
         <div class="iptPannel" id="iptPannel">
             <a href="https://www.mike652638.com/projects/wiki.html">
-                <img src="wiki/wikiFont.png" alt="wiki logo">
+                <img src="wiki/img/wikiFont.png" alt="wiki logo">
             </a>
             <input type="text" name="kywdIpt" class="kywdIpt" id="kywdIpt">
             <input type="button" name="kywdBtn" value="搜索" class="kywdBtn" id="kywdBtn">
@@ -72,7 +72,7 @@
     <div id="loaderNote" class="loaderNote">
         正在从服务器请求数据, 请稍后 ...
         <br>
-        <br> 如果数据请求时间过长, 则说明您可能被墙咯, 可以<a target="_blank" href="https://www.mike652638.com/download">点我下载翻墙工具</a>尝试科学上网哦 ...
+        <br> 如果数据请求时间过长, 则说明您可能被墙咯, 可以<a target="_blank" href="http://pan.baidu.com/s/1c28FK9U">点我下载翻墙工具</a>尝试科学上网哦 ...
     </div>
 </body>
 


### PR DESCRIPTION
1. The previous link to download vpn is https://www.mike652638.com/download, which may sometimes fail and redirect to home page with unknown error, so the links are updated directly to shared resources on my Baidu NetDisk.
2. The loading animation was changed to match better with the design of result page.