### PR TITLE
修复词条联想框出现在页面中央的BUG

### DIFF
--- a/wiki/wiki.js
+++ b/wiki/wiki.js
@@ -252,10 +252,8 @@ $(document).ready(function() {
             timeStart = Date.parse(new Date());
             resultsSum = null;
             resultNum = 0;
-            /**存在一个BUG: 主页搜索框输入文字会开启联想功能, 回车键同样会触发oninput事件, 下面是不得已的方法**/
-            setTimeout(function() {
-                $("#srchRelative").css("display", "none");
-            }, 1500);
+            /**存在一个BUG: 主页搜索框输入文字会开启联想功能, 回车键同样会触发oninput事件, 需要隐藏词条联想框**/
+            $("#srchRelative").css("display", "none");
             if (isMainPage === "block") {
                 keyword = $("#srchIpt").val();
                 $("#kywdIpt").val(keyword);
@@ -320,6 +318,9 @@ $(document).ready(function() {
         var windowHeight = $(this).height(),
             scrollTop = $(this).scrollTop(),
             scrollHeight = $(document).height();
+
+        /**检测到页面滑动时词条联想框应该隐藏掉, 因为它是绝对定位的, 会出现在页面半中央位置, 碍眼睛**/
+        $("#srchRelative").css("display", "none");
 
         if (isAutoLoad === "yes" && scrollHeight - scrollTop - windowHeight <= 200) {
             if (hasExed === "no") {


### PR DESCRIPTION
主页输入关键词再按回车键, 会触发oninput事件, 导致搜索结果页中央显示词条联想框(绝对定位), 同样的BUG存在于搜索结果页点击搜索框后页面滚动时词条联想框在页面中央不消失, 因此在这两个函数内均加入了$("#srchRelative").css("display", "none");解决了这个问题